### PR TITLE
Update typedoc peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Asger Jensen <asger.jensen@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "typedoc": "^0.5.3"
+    "typedoc": ">=0.5.3"
   },
   "devDependencies": {
     "@types/handlebars": "^4.0.31",


### PR DESCRIPTION
This plugin seems to work with all versions of typedoc >= 0.5.3, so
update the peerDependency accordingly.

Otherwise, npm would output warnings about a missing peer dependency
and also "npm ls" would fail with an error in projects that use the
latest typedoc (0.8.0).